### PR TITLE
Edit Contacts Migration

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -14,7 +14,7 @@ class ContactController extends Controller
       if($contact->validate($data)){
         return Contact::firstOrCreate(['email' => $data['email']], $data);
       } else {
-        return $contact->errors();
+        return array("errors" => $contact->errors());
       }
     }
 }

--- a/database/migrations/2016_10_20_205622_create_contacts_table.php
+++ b/database/migrations/2016_10_20_205622_create_contacts_table.php
@@ -17,8 +17,8 @@ class CreateContactsTable extends Migration
             $table->increments('id');
             $table->timestamps();
             $table->string('email');
-            $table->integer('organization_id');
-            $table->string('tags', 255);
+            $table->integer('organization_id')->default(1);
+            $table->string('tags', 255)->nullable()->default("POL");
         });
     }
 


### PR DESCRIPTION
Gave default values to `organization_id` and `tags`, `tags` are also nullable. Returning Contact creation errors as an associate array.